### PR TITLE
Add additional soname for unix

### DIFF
--- a/src/libsnappy.lisp
+++ b/src/libsnappy.lisp
@@ -1,6 +1,7 @@
 (in-package :thnappy)
 
 (define-foreign-library libsnappy
+  (:unix (:or "libsnappy.so" "libsnappy.so.1"))
   (t (:default "libsnappy")))
 
 (use-foreign-library libsnappy)


### PR DESCRIPTION
Adds libsnappy.so.1 to the cffi definition of libsnappy, which allows the library to load on fedora 19 and possibly others.
